### PR TITLE
#hireme | z-index to over fb messanger icon.

### DIFF
--- a/resources/assets/js/components/hireMe/hireMe.vue
+++ b/resources/assets/js/components/hireMe/hireMe.vue
@@ -281,6 +281,11 @@ export default {
 
 <style lang="scss">
 
+  .v-dialog__content{
+    z-index: 9999999999 !important;
+  }
+
+
   .hire-me-url-btn{
     height: 50px;
     @media screen and (max-width: 425px) {


### PR DESCRIPTION
- higher the z-index to overlap the messanger icon.